### PR TITLE
Changed cursor to be "text" when in text area to be consistent with other text editors

### DIFF
--- a/notecalc.html
+++ b/notecalc.html
@@ -155,7 +155,7 @@
     const canvas = document.getElementById("canvas");
     const ctx = canvas.getContext("2d");
     const overlay_ctx = overlay_canvas.getContext("2d");
-    const cursor_styles = ['default', 'default', 'w-resize', 'pointer'];
+    const cursor_styles = ['text', 'default', 'w-resize', 'pointer'];
 
     let next_full_reparse_tick = 0;
     let app_ptr;


### PR DESCRIPTION
I can't really test it because I'm having some issues with building, but I think I think it would make it more consistent with other text editors.