### PR TITLE
Adding an option to run it using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rnsloan/wasm-pack
+
+RUN apt update && apt install -y nodejs npm
+RUN npm install -g serve
+
+EXPOSE 5000/tcp
+EXPOSE 5000/udp
+
+RUN git clone https://github.com/bbodi/notecalc3.git .
+RUN chmod +x compile_and_run.bat
+
+CMD ./compile_and_run.bat

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ git clone https://github.com/bbodi/notecalc3.git
 
 Then, open your browser and go to  [http://localhost:5000/notecalc](http://localhost:5000/notecalc).
 
+## Run using docker
+
+You can also run using a container with this command:
+
+```sh
+git clone https://github.com/bbodi/notecalc3.git
+cd notecalc3
+docker build . --tag notecalc3
+docker run --rm -d -p 5000:5000 notecalc3
+```
+
+Then, open your browser and go to  [http://localhost:5000/notecalc](http://localhost:5000/notecalc).
+
 ## Libraries used
 Huge thanks for the following libraries
 - https://mathjs.org/


### PR DESCRIPTION
Maybe we could add a simpler option for users to run Notecalc locally, so I created a Dockerfile that can be used in the future to create an image in Dockerhub.

With this option users don't need to install rust or nodejs in their machines.