### PR TITLE
Fix Dockerfile failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM rnsloan/wasm-pack
+FROM node:lts
 
-RUN apt update && apt install -y nodejs npm
-RUN npm install -g serve
+RUN npm install -g serve wasm-pack
 
 EXPOSE 5000/tcp
 EXPOSE 5000/udp
 
-RUN git clone https://github.com/bbodi/notecalc3.git .
+COPY . .
 RUN chmod +x compile_and_run.bat
 
 CMD ./compile_and_run.bat

--- a/compile_and_run.bat
+++ b/compile_and_run.bat
@@ -1,2 +1,2 @@
 wasm-pack build --dev --target no-modules frontend-web
-serve .
+serve -p 5000 .


### PR DESCRIPTION
Issues:
1) Serve by default no longer listens on port 5000, so adding an option to force it. https://github.com/vercel/serve/blob/d06104a2de569b1bef57f567f853ab3cfd0024e4/source/main.ts#L56C1-L56C67

2) Docker base image `rnsloan/wasm-pack` has not been updated for 6 yrs and packages are all out dated. So update to a more up to date image.